### PR TITLE
Add new repositories to README table

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -34,7 +34,8 @@ SUSE offers Linux, container management, and edge computing solutions.
 |Repository|Description|
 |--|--|
 |[susemanager-ci](https://github.com/SUSE/susemanager-ci)|CI infrastructure for SUSE Multi-Linux Manager|
-
+|[salt-netapi-client](https://github.com/SUSE/salt-netapi-client)|Java bindings for the Salt API|
+|[salt-formulas](https://github.com/SUSE/salt-formulas)|Salt Formulas for SUSE Enterprise Linux and openSUSE Linux|
 
 ## SUSE Customer Center
 


### PR DESCRIPTION
These are some of the public repos in the SUSE organization related to Multi-Linux Manager and owned by the MLM teams. I assume that we don't want to list private repos in this README table.